### PR TITLE
Fix Cloudflare 403

### DIFF
--- a/lib/api/request.js
+++ b/lib/api/request.js
@@ -1,18 +1,18 @@
-const requestPromise = require("request-promise"),
-      cheerio        = require("cheerio");
+const cheerio = require("cheerio"),
+    puppeteer = require('puppeteer');
       
 module.exports =  {
 
     async req(url) {
 
         try {
-            let $ = await requestPromise({
-                uri: url,
-                transform: function (body) {
-                    return cheerio.load(body, { decodeEntities: false });
-                }
-            });
-            return $;
+            const browser = await puppeteer.launch();
+            const page = await browser.newPage();
+            await page.setUserAgent('Mozilla/5.0 (Windows NT 5.1; rv:5.0) Gecko/20100101 Firefox/5.0')
+            await page.goto(url);
+            const html = await page.evaluate(() => document.body.innerHTML);
+            await browser.close();
+            return cheerio.load(html, {decodeEntities: false});
         } 
         catch (e) {
             console.log(new TypeError("An error occured while requesting this url."))

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "remove-accents": "^0.4.2",
-    "request": "^2.88.2",
-    "request-promise": "^4.2.6"
+    "puppeteer": "^17.1.3"
   }
 }


### PR DESCRIPTION
Hi there,

This patch fixes the Cloudflare 403 error. I got this error when I was doing some tests with my API. To fix that I used “puppeteer” and removed the deprecated “request” & “request-promise” packages.
I tested it, and it works perfectly now :) 

Best Regards